### PR TITLE
fix iso standard for language

### DIFF
--- a/admin/core/scalars/scalar_Language.graphql
+++ b/admin/core/scalars/scalar_Language.graphql
@@ -1,3 +1,3 @@
 # The Language type represents Language values. A good example might be a Hotel Description Language.
-# In queries or mutations, Language fields have to be specified in ISO 3166-1 alpha-2 format with enclosing double quotes "es".
+# In queries or mutations, Language fields have to be specified in ISO 639-1 format with enclosing double quotes "en".
 scalar Language


### PR DESCRIPTION
@arquio ISO 3166-1 alpha-2 was wrong, it's only for country code. replaced by [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1)