### PR TITLE
Fixed inut updateGroup

### DIFF
--- a/admin/iam/inputs/input_UpdateGroupInput.graphql
+++ b/admin/iam/inputs/input_UpdateGroupInput.graphql
@@ -1,5 +1,5 @@
 input UpdateGroupInput{
-  api: ID!
+  api: [ID!]!
   group: ID!
   info: String
 }


### PR DESCRIPTION
Change input of updateGroup. Now the field API is an array. Multiple APIs can be assigned or deleted in one call.