### PR TITLE
fixed error of client/supplier input description

### DIFF
--- a/alertsx/alertsx/inputs/input_AlertConfigurationInputAverageTime.graphql
+++ b/alertsx/alertsx/inputs/input_AlertConfigurationInputAverageTime.graphql
@@ -58,10 +58,10 @@ input AlertConfigurationInputAverageTime {
   "Possibility to filter traffic by errorTypes"
   errorType: [ErrorTypeInput!] 
   # supplier codes
-  "Possibility to filter traffic by suppliers (hub provider"
+  "Possibility to filter traffic by suppliers"
 	supplier:[AlertObjectInput!]
   # client codes
-  "Possibility to filter traffic by clients (hub user)"
+  "Possibility to filter traffic by clients"
 	client:[AlertObjectInput!]
   # group codes
   "Must filter traffic by group. Only PRODUCT group type is allowed"

--- a/alertsx/alertsx/inputs/input_AlertConfigurationInputErrorRate.graphql
+++ b/alertsx/alertsx/inputs/input_AlertConfigurationInputErrorRate.graphql
@@ -49,10 +49,10 @@ input AlertConfigurationInputErrorRate {
   "Possibility to filter traffic by errorTypes"
   errorType: [ErrorTypeInput!] 
   # supplier codes
-  "Possibility to filter traffic by suppliers (hub provider)"
+  "Possibility to filter traffic by suppliers"
 	supplier:[AlertObjectInput!]
   # client codes
-  "Possibility to filter traffic by clients (hub user)"
+  "Possibility to filter traffic by clients"
 	client:[AlertObjectInput!]
   # group codes
   "Must filter traffic by group. Only PRODUCT group type is allowed"

--- a/alertsx/alertsx/inputs/input_AlertConfigurationInputNoTraffic.graphql
+++ b/alertsx/alertsx/inputs/input_AlertConfigurationInputNoTraffic.graphql
@@ -36,10 +36,10 @@ input AlertConfigurationInputNoTraffic {
   "Possibility to filter traffic by errorTypes"
   errorType: [ErrorTypeInput!] 
   # supplier codes
-  "Possibility to filter traffic by suppliers (hub provider)"
+  "Possibility to filter traffic by suppliers"
 	supplier:[AlertObjectInput!]
   # client codes
-  "Possibility to filter traffic by clients (hub user)"
+  "Possibility to filter traffic by clients"
 	client:[AlertObjectInput!]
   # group codes
   "Must filter traffic by group. Only PRODUCT group type is allowed"

--- a/alertsx/alertsx/inputs/input_AlertConfigurationInputPeakTraffic.graphql
+++ b/alertsx/alertsx/inputs/input_AlertConfigurationInputPeakTraffic.graphql
@@ -41,10 +41,10 @@ input AlertConfigurationInputPeakTraffic {
   "Possibility to filter traffic by errorTypes"
   errorType: [ErrorTypeInput!] 
   # supplier codes
-  "Possibility to filter traffic by suppliers (hub provider)"
+  "Possibility to filter traffic by suppliers"
 	supplier:[AlertObjectInput!]
   # client codes
-  "Possibility to filter traffic by clients (hub user)"
+  "Possibility to filter traffic by clients"
 	client:[AlertObjectInput!]
   # group codes
   "Must filter traffic by group. Only PRODUCT group type is allowed"

--- a/alertsx/alertsx/inputs/input_AlertUpdateConfigurationInputAverageTime.graphql
+++ b/alertsx/alertsx/inputs/input_AlertUpdateConfigurationInputAverageTime.graphql
@@ -58,10 +58,10 @@ input AlertUpdateConfigurationInputAverageTime {
   "Possibility to filter traffic by errorTypes"
   errorType: [ErrorTypeInput!] 
   # supplier codes
-  "Possibility to filter traffic by suppliers (hub provider)"
+  "Possibility to filter traffic by suppliers"
 	supplier:[AlertObjectInput!]
   # client codes
-  "Possibility to filter traffic by clients (hub user)"
+  "Possibility to filter traffic by clients"
 	client:[AlertObjectInput!]
   # group codes
  "Must filter traffic by group. Only PRODUCT group type is allowed"

--- a/alertsx/alertsx/inputs/input_AlertUpdateConfigurationInputErrorRate.graphql
+++ b/alertsx/alertsx/inputs/input_AlertUpdateConfigurationInputErrorRate.graphql
@@ -49,10 +49,10 @@ input AlertUpdateConfigurationInputErrorRate {
   "Possibility to filter traffic by errorTypes"
   errorType: [ErrorTypeInput!] 
   # supplier codes
-  "Possibility to filter traffic by suppliers (hub provider)"
+  "Possibility to filter traffic by suppliers"
 	supplier:[AlertObjectInput!]
   # client codes
-  "Possibility to filter traffic by clients (hub user)"
+  "Possibility to filter traffic by clients"
 	client:[AlertObjectInput!]
   # group codes
   "Must filter traffic by group. Only PRODUCT group type is allowed"

--- a/alertsx/alertsx/inputs/input_AlertUpdateConfigurationInputNoTraffic.graphql
+++ b/alertsx/alertsx/inputs/input_AlertUpdateConfigurationInputNoTraffic.graphql
@@ -36,10 +36,10 @@ input AlertUpdateConfigurationInputNoTraffic {
   "Possibility to filter traffic by errorTypes"
   errorType: [ErrorTypeInput!] 
   # supplier codes
-  "Possibility to filter traffic by suppliers (hub provider)"
+  "Possibility to filter traffic by suppliers"
 	supplier:[AlertObjectInput!]
   # client codes
-  "Possibility to filter traffic by clients (hub user)"
+  "Possibility to filter traffic by clients"
 	client:[AlertObjectInput!]
   # group codes
  "Must filter traffic by group. Only PRODUCT group type is allowed"

--- a/alertsx/alertsx/inputs/input_AlertUpdateConfigurationInputPeakTraffic.graphql
+++ b/alertsx/alertsx/inputs/input_AlertUpdateConfigurationInputPeakTraffic.graphql
@@ -44,10 +44,10 @@ input AlertUpdateConfigurationInputPeakTraffic {
   "Possibility to filter traffic by errorTypes"
   errorType: [ErrorTypeInput!] 
   # supplier codes
-  "Possibility to filter traffic by suppliers (hub provider)"
+  "Possibility to filter traffic by suppliers"
 	supplier:[AlertObjectInput!]
   # client codes
-  "Possibility to filter traffic by clients (hub user)"
+  "Possibility to filter traffic by clients"
 	client:[AlertObjectInput!]
   # group codes
  "Must filter traffic by group. Only PRODUCT group type is allowed"


### PR DESCRIPTION
Fixed description mistake for client & supplier. Input must be their codes, not their hubuser/hubProvider