### PR TITLE
add new field to PaymentCardInput and deprecate old one

### DIFF
--- a/admin/core/inputs/input_PaymentCardInput.graphql
+++ b/admin/core/inputs/input_PaymentCardInput.graphql
@@ -1,8 +1,12 @@
 # Input PaymentCard, if the payment is done by credit card, is it mandatory to specify the payment type and the credit card information
 input PaymentCardInput {
   # Indicates the supported card type, the supported card for this option is shown in Quote step.
-  cardType: PaymentCardType!
-  
+  # @deprecated(reason: "deprecated from 2019-07-31. Please, use type")
+  cardType: String
+
+  # Indicates the supported card type, the supported card for this option is shown in Quote step.
+  type: PaymentCardType
+
   # Contains owner's name
   holder: HolderInput!
   


### PR DESCRIPTION
Hi, @arquio 
We found an error when the user send argument using "inline arguments"  for enum field, it only accept value without the double quote, In this case cardTypes  if we send "VI"(with double quote) we will get error.
To fix it we decide to create another field using Enum type, and deprecate the old one