### PR TITLE
Make new markets field optional

### DIFF
--- a/hotelx/cfg/inputs/input_HotelXDefaultSettingsDataInput.graphql
+++ b/hotelx/cfg/inputs/input_HotelXDefaultSettingsDataInput.graphql
@@ -11,7 +11,7 @@ input HotelXDefaultSettingsDataInput {
   # @deprecated(reason: "deprecated from 2019-12-11.")
   market: String
   # Targeted zones, countries or point-ofsale-to be used in request.
-  markets: [String!]!
+  markets: [String!]
   # Group of timeouts to be used in the differents services
   timeout: TimeoutInput!
   # Business rules.


### PR DESCRIPTION
Although the query DeffaultSettings is only used internally, we need to make a fix to the markets field we've just added to make it optional. So both market and markets has to be optional from now on.