### PR TITLE
PageInfo from static object Deprecation in progress

### DIFF
--- a/hotelx/hotstc/objects/object_BoardConnection.graphql
+++ b/hotelx/hotstc/objects/object_BoardConnection.graphql
@@ -2,5 +2,5 @@
 type BoardConnection {
   edges: [BoardEdge]
   # Indicates info about page
-  pageInfo: PageInfo!
+  pageInfo: PageInfo! @deprecated(reason: "deprecated from 2019-12-04. non functional")
 }

--- a/hotelx/hotstc/objects/object_CategoryConnection.graphql
+++ b/hotelx/hotstc/objects/object_CategoryConnection.graphql
@@ -2,5 +2,5 @@
 type CategoryConnection {
   edges: [CategoryEdge]
   # Indicates info about page
-  pageInfo: PageInfo!
+  pageInfo: PageInfo! @deprecated(reason: "deprecated from 2019-12-04. non functional")
 }

--- a/hotelx/hotstc/objects/object_DestinationConnection.graphql
+++ b/hotelx/hotstc/objects/object_DestinationConnection.graphql
@@ -3,5 +3,5 @@ type DestinationConnection {
   edges: [DestinationEdge]
   token: String!
   # Indicates info about page
-  pageInfo: PageInfo!
+  pageInfo: PageInfo! @deprecated(reason: "deprecated from 2019-12-04. non functional")
 }

--- a/hotelx/hotstc/objects/object_HotelConnection.graphql
+++ b/hotelx/hotstc/objects/object_HotelConnection.graphql
@@ -4,5 +4,5 @@ type HotelConnection {
   count: Int!
   token: String
   # Indicates info about page
-  pageInfo: PageInfo!
+  pageInfo: PageInfo! @deprecated(reason: "deprecated from 2019-12-04. non functional")
 }

--- a/hotelx/hotstc/objects/object_HotelXAmenityConnection.graphql
+++ b/hotelx/hotstc/objects/object_HotelXAmenityConnection.graphql
@@ -3,5 +3,5 @@ type HotelXAmenityConnection {
   edges: [HotelXAmenityEdge!]
 
   # Page info of the connection
-  pageInfo: PageInfo!
+  pageInfo: PageInfo! @deprecated(reason: "deprecated from 2019-12-04. non functional")
 }

--- a/hotelx/hotstc/objects/object_RoomConnection.graphql
+++ b/hotelx/hotstc/objects/object_RoomConnection.graphql
@@ -3,5 +3,5 @@ type RoomConnection {
   edges: [RoomEdge]
   token: String
   # Indicates info about page
-  pageInfo: PageInfo!
+  pageInfo: PageInfo! @deprecated(reason: "deprecated from 2019-12-04. non functional")
 }


### PR DESCRIPTION
The functionality that implies filling the PageInfo field for all the static hotelx product, is not available and it would never be (in the near future). To avoid confusion among our clients, we thought the best solution is to deprecate this field.