### PR TITLE
optionsQuota deprecated

### DIFF
--- a/hotelx/hubgra/inputs/input_BusinessRulesInput.graphql
+++ b/hotelx/hubgra/inputs/input_BusinessRulesInput.graphql
@@ -1,6 +1,7 @@
 # List of business rules to use as filter on the options.
 input BusinessRulesInput {
   # Options quota per search. Maximum numbers of options to be returned by the search query.
+  # @deprecated(reason: "deprecated from 2019-12-04. This option will be only configurable by settings.")
   optionsQuota: Int
   
   # Different business rules to filter the returned options.


### PR DESCRIPTION
BusinessRulesInput optionsQuota for all query and mutation input settings deprecated. We've decided to deprecate this field, since there's already a optionsQuota configuration through default settings, data base and consul.