### PR TITLE
Added rooms so multiroom can be implemented in the overall booking process

### DIFF
--- a/package/inputs/input_BookWhereInput.graphql
+++ b/package/inputs/input_BookWhereInput.graphql
@@ -13,4 +13,6 @@ input BookWhereInput {
   passengers: [PackagePassengerInput!]!
   """ String list of tokens that are received in the itinerary map from quote """
   productTokens: [String!]!
+  """  List of rooms including pax info """
+  rooms : [RoomBook]
 }

--- a/package/inputs/input_PackagePassengerQuote.graphql
+++ b/package/inputs/input_PackagePassengerQuote.graphql
@@ -1,0 +1,4 @@
+input PackagePassengerQuote{
+  """ Passenger age """
+  age: Int!  
+}

--- a/package/inputs/input_QuoteWhereInput.graphql
+++ b/package/inputs/input_QuoteWhereInput.graphql
@@ -5,4 +5,6 @@ input QuoteWhereInput {
   optionId: String!
   """ passengers List of passengers included in reservation """
   passengers : [Int!]
+  """ Rooms including the number of paxes in each one """
+  rooms : [RoomQuote]
 }

--- a/package/inputs/input_RoomBook.graphql
+++ b/package/inputs/input_RoomBook.graphql
@@ -1,0 +1,4 @@
+input RoomBook {
+  """ Information of each passenger for the room """
+  passengers: [PackagePassengerInput!]!
+}

--- a/package/inputs/input_RoomQuote.graphql
+++ b/package/inputs/input_RoomQuote.graphql
@@ -1,0 +1,4 @@
+input RoomQuote {
+  """ Information of each passenger for the room """
+  passengers: [PackagePassengerQuote]
+}

--- a/package/objects/object_BookPayload.graphql
+++ b/package/objects/object_BookPayload.graphql
@@ -23,6 +23,8 @@ type BookPayload {
   origin: PackageLocation
   """ Paxes for the option """
   paxes: Paxes
+  """ Rooms applying to the option """
+  rooms: [PackageRoom]
   """ Price applied to the booking """
   price: PackagePrice
   """ Remarks of the booking """

--- a/package/objects/object_BookingPayload.graphql
+++ b/package/objects/object_BookingPayload.graphql
@@ -23,6 +23,8 @@ type BookingPayload {
   origin: PackageLocation
   """ Paxes for the option """
   paxes: Paxes
+  """ Rooms applying to the option """
+  rooms: [PackageRoom]
   """ Price applied to the booking """
   price: PackagePrice
   """ Remarks of the booking (may not be specified in this query) """

--- a/package/objects/object_PackageRoom.graphql
+++ b/package/objects/object_PackageRoom.graphql
@@ -1,0 +1,6 @@
+type PackageRoom{
+    """ List of possible accomodations for this option """
+    accomodationRefs: [String]
+    """ List of passengers for the room """
+    pax: [PackagePax]
+}

--- a/package/objects/object_QuotePayload.graphql
+++ b/package/objects/object_QuotePayload.graphql
@@ -31,6 +31,8 @@ type QuotePayload {
   remarks: [Remark!]
   """ Paxes for the option """
   paxes: Paxes
+  """ Rooms applying to the option """
+    rooms: [PackageRoom]
   """ Status of the package (Available, On_Request...) """
   status: PackageStatus
   """ List of transports included in the booking """

--- a/package/objects/object_Rate.graphql
+++ b/package/objects/object_Rate.graphql
@@ -7,4 +7,6 @@ type Rate{
     nonCommissionablePriceAmount: Float!
     """ Paxes applying to this price and option """
     paxes: Paxes
+    """ Rooms applying to the option """
+    rooms: [PackageRoom]
 }


### PR DESCRIPTION
Estos campos son para sustituir las listas de paxes que hay en las respuestas y en los inputs sin estar dentro de room, diría que así como están definidos son completamente opcionales tanto de enviar en input como de recibir a modo de respuesta, si no es el caso indicádmelo y hago el cambio pertinentes, ya que de momento no debería ser obligatorio y basta que este para hacer pruebas junto con logi/VECI